### PR TITLE
Fixed a bug (all auto converter have the same inventory)

### DIFF
--- a/src/main/java/com/mattdahepic/autooredictconv/converter/TileConverter.java
+++ b/src/main/java/com/mattdahepic/autooredictconv/converter/TileConverter.java
@@ -16,7 +16,7 @@ public class TileConverter extends TileEntity implements ISidedInventory {
     public static final String NAME = "converter";
     public static final String INVENTORY_NAME = "Auto Converter";
     public static final int SIZE = 15;
-    private ItemStack[] contents = new ItemStack[SIZE];
+    public ItemStack[] contents = new ItemStack[SIZE];
     public TileConverter () {}
     @Override
     public int getSizeInventory() {

--- a/src/main/java/com/mattdahepic/autooredictconv/converter/TileConverter.java
+++ b/src/main/java/com/mattdahepic/autooredictconv/converter/TileConverter.java
@@ -16,7 +16,7 @@ public class TileConverter extends TileEntity implements ISidedInventory {
     public static final String NAME = "converter";
     public static final String INVENTORY_NAME = "Auto Converter";
     public static final int SIZE = 15;
-    public static ItemStack[] contents = new ItemStack[SIZE];
+    private ItemStack[] contents = new ItemStack[SIZE];
     public TileConverter () {}
     @Override
     public int getSizeInventory() {


### PR DESCRIPTION
Before correction, when I break a auto converter, the blocks of another auto converter drop.

Sorry for my bad english, I'm French.